### PR TITLE
Warn user about unsupported Ecto constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,23 @@ defmodule MyApp.Repo do
 end
 ```
 
-## Ignored Ecto Constraints
+## Unsupported Ecto Constraints
+
+The changeset functions
+[`foreign_key_constraint/3`](http://hexdocs.pm/ecto/Ecto.Changeset.html#foreign_key_constraint/3)
+and
+[`unique_constraint/3`](http://hexdocs.pm/ecto/Ecto.Changeset.html#unique_constraint/3)
+are not supported by `Sqlite.Ecto` because the underlying SQLite database does
+not provide enough information when such constraints are violated to support
+the features.
+
+Note that SQLite **does** support both unique and foreign key constraints via
+[`unique_index/3`](http://hexdocs.pm/ecto/Ecto.Migration.html#unique_index/3)
+and [`references/2`](http://hexdocs.pm/ecto/Ecto.Migration.html#references/2),
+respectively.  When such constraints are violated, they will raise
+`Sqlite.Ecto.Error` exceptions.
+
+## Silently Ignored Options
 
 There are a few Ecto options which `Sqlite.Ecto` silently ignores because
 SQLite does not support them and raising an error on them does not make sense:

--- a/lib/sqlite_ecto/error.ex
+++ b/lib/sqlite_ecto/error.ex
@@ -8,5 +8,15 @@ defmodule Sqlite.Ecto.Error do
   def exception({type, msg}), do: %__MODULE__{sqlite: {type, to_string(msg)}}
   def exception(msg), do: %__MODULE__{sqlite: msg}
 
+  require Logger
+
+  def to_constraints(%__MODULE__{sqlite: {:constraint, "UNIQUE constraint failed: " <> _}}) do
+    Logger.warn "unique_constraint/3 is unsupported by SQLite"
+    []
+  end
+  def to_constraints(%__MODULE__{sqlite: {:constraint, "FOREIGN KEY constraint failed"}}) do
+    Logger.warn "foreign_key_constraint/3 is unsupported by SQLite"
+    []
+  end
   def to_constraints(_), do: []
 end

--- a/lib/sqlite_ecto/error.ex
+++ b/lib/sqlite_ecto/error.ex
@@ -5,18 +5,18 @@ defmodule Sqlite.Ecto.Error do
   def message(%__MODULE__{sqlite: msg}), do: "UNKNOWN: #{inspect msg}"
   def message(%__MODULE__{message: msg}), do: msg
 
+  # handle unique constraint failures
+  def exception({:constraint, msg = 'UNIQUE constraint failed:' ++ _}) do
+    msg = to_string(msg) <> "; unique_constraint/3 is unsupported by SQLite"
+    %__MODULE__{sqlite: {:constraint, msg}}
+  end
+  # handle foreign key constraint failures
+  def exception({:constraint, msg = 'FOREIGN KEY constraint failed'}) do
+    msg = to_string(msg) <> "; foreign_key_constraint/3 is unsupported by SQLite"
+    %__MODULE__{sqlite: {:constraint, msg}}
+  end
   def exception({type, msg}), do: %__MODULE__{sqlite: {type, to_string(msg)}}
   def exception(msg), do: %__MODULE__{sqlite: msg}
 
-  require Logger
-
-  def to_constraints(%__MODULE__{sqlite: {:constraint, "UNIQUE constraint failed: " <> _}}) do
-    Logger.warn "unique_constraint/3 is unsupported by SQLite"
-    []
-  end
-  def to_constraints(%__MODULE__{sqlite: {:constraint, "FOREIGN KEY constraint failed"}}) do
-    Logger.warn "foreign_key_constraint/3 is unsupported by SQLite"
-    []
-  end
   def to_constraints(_), do: []
 end


### PR DESCRIPTION
@josevalim Possible fix for #37.  I don't have any sufficiently complex changesets to test with, but would the warnings added to `to_constraint/1` be too noisy in, e.g., a typical Phoenix app?  Should they instead be infos or debugs?
