### PR TITLE
Fix LIKE and ILIKE clauses

### DIFF
--- a/lib/sqlite_ecto/query.ex
+++ b/lib/sqlite_ecto/query.ex
@@ -276,7 +276,7 @@ defmodule Sqlite.Ecto.Query do
   binary_ops =
     [==: "=", !=: "!=", <=: "<=", >=: ">=", <:  "<", >:  ">",
      and: "AND", or: "OR",
-     ilike: "ILIKE", like: "LIKE"]
+     ilike: "LIKE", like: "LIKE"]
 
   @binary_ops Keyword.keys(binary_ops)
 


### PR DESCRIPTION
There is no `ILIKE` clause in SQLite. The `LIKE` clause is, by default, case-insensitive however, so this can simply be used. Ecto's `like` function is suppose to be case-sensitive though, and I'm not sure how to enforce this behaviour in SQLite. I realise there is a pragma directive to toggle this behaviour, but I don't think there is a way to achieve this at the SQL syntax level.

Edit
see related discussion first: https://github.com/elixir-lang/ecto/pull/1431
